### PR TITLE
feat: adiciona parametros para usuario poder forcar (re)build

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,15 @@ cp .env.example .env
 php builder.php
 ```
 
+To bypass the confirmation prompt and force rebuild, you can simply pass the `-y` parameter.
+
 **4.** Once you have created them, data can be inserted (or updated) whenever needed by:
 
 ```sh
 php main.php
 ```
+
+To force build/rebuild while running main.php, you can pass the `-f` parameter.
 
 **5.** To check the last time the ETL scripts were executed, use the `check.php` script:
 

--- a/builder.php
+++ b/builder.php
@@ -7,7 +7,9 @@ use Src\Utils\BuilderUtils;
 
 pcntl_alarm(10 * 60); // Kills script if it's taking too long.
 
-CommonUtils::timer(function () {
-    $tableGroups = BuilderUtils::getAllTableGroups();
-    BuilderUtils::setupDatabase($tableGroups);
+// user param
+$forceRebuild = in_array("-y", $argv);
+
+CommonUtils::timer(function () use ($forceRebuild) {
+    BuilderUtils::setupDatabase($forceRebuild);
 }, basename(__FILE__));

--- a/main.php
+++ b/main.php
@@ -2,6 +2,7 @@
 
 require_once __DIR__ . "/vendor/autoload.php";
 
+use Src\Utils\BuilderUtils;
 use Src\Utils\CommonUtils;
 use Src\Utils\MessageUtils;
 
@@ -16,8 +17,16 @@ $scripts = [
     'questSocioEcon',
     'lattes',
 ];
+// user param
+$forceBuildOrRebuild = in_array("-f", $argv);
 
-CommonUtils::timer(function () use ($scripts) {
+CommonUtils::timer(function () use ($scripts, $forceBuildOrRebuild) {
+
+    if ($forceBuildOrRebuild === true) {
+        // trigger a (re)build
+        BuilderUtils::setupDatabase($forceBuildOrRebuild);
+    }
+
     foreach ($scripts as $script) {
         // run script
         include "src/Scripts/$script.php";

--- a/src/Utils/BuilderUtils.php
+++ b/src/Utils/BuilderUtils.php
@@ -100,12 +100,15 @@ class BuilderUtils
         return $missingColumnFound;
     }
 
-    public static function setupDatabase()
+    public static function setupDatabase(bool $forceRebuild)
     {
         $requestingRebuild = false;
         $missingColumnFound = self::validateCurrentDatabaseStructure(false);
 
-        if ($missingColumnFound === false) {
+        if ($forceRebuild === true) {
+            $requestingRebuild = true;
+        }
+        elseif ($missingColumnFound === false) {
             $requestingRebuild = self::offerRebuild();
         }
 


### PR DESCRIPTION
permite utilizar parâmetros para

- ignorar o prompt de confirmação de rebuild do script builder (`php builder.php -y`);

- dispensar o builder e forçar re/build diretamente no script main (`php main.php -f`).